### PR TITLE
Use size=2048 for PFPs so they don't look awful

### DIFF
--- a/quad/modules/pic.js
+++ b/quad/modules/pic.js
@@ -13,7 +13,7 @@ function pictureEmbed(user, t) {
             height: 512
         },
         image: {
-            url: user.avatarURL.replace("size=128", "size=512")
+            url: user.avatarURL.replace("size=128", "size=2048")
         }
     }
 }


### PR DESCRIPTION
512x looks terrible. The only time it looks good is when the original PFPs themselves are 512x512. However, most are much larger. Therefore, to return the best image quality possible, Quad should use 2048x.